### PR TITLE
hex: add aarch64 neon version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "byteorder",
+ "cc",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ rpgp = [ "pgp", "rand", "chrono", "smallvec", "sha-1" ]
 [dev-dependencies]
 hex = "^0.4"
 
+[build-dependencies]
+cc = "1.0"
+
 [dependencies]
 log = { version = "^0.4", features = [ "std" ] }
 pgp = { version = "^0.7", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use cc::Build;
+        Build::new().file("src/hex_neon.c").compile("hex");
+    }
+}

--- a/src/hex_neon.c
+++ b/src/hex_neon.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <arm_neon.h>
+
+const uint8_t nine = 9;
+const uint8_t and_mask = 0xf;
+const uint8_t bin_a = 0x37;
+
+void sha1_to_hex_neon(const uint8_t *binary, uint8_t *hex) {
+  uint8x16_t ascii_zero = vld1q_dup_u8((const uint8_t*)"0");
+  uint8x16_t nines = vld1q_dup_u8(&nine);
+  uint8x16_t ascii_a = vld1q_dup_u8(&bin_a);
+  uint8x16_t and4bits = vld1q_dup_u8(&and_mask);
+
+  uint8x16_t invec = vld1q_u8(binary);
+  uint8x16_t masked1 = vandq_u8(invec, and4bits);
+  uint8x16_t masked2 = vandq_u8(vshrq_n_u8((invec), 4), and4bits);
+
+  uint8x16_t cmpmask1 = vcgtq_u8(masked1, nines);
+  uint8x16_t cmpmask2 = vcgtq_u8(masked2, nines);
+
+  uint8x16_t masked1_k = vaddq_u8(masked1, vbslq_u8(cmpmask1, ascii_a, ascii_zero));
+  uint8x16_t masked2_k = vaddq_u8(masked2, vbslq_u8(cmpmask2, ascii_a, ascii_zero));
+
+  uint8x16_t res1 = vzip1q_u8(masked2_k, masked1_k);
+  uint8x16_t res2 = vzip2q_u8(masked2_k, masked1_k);
+
+  vst1q_u8(hex, res1);
+  vst1q_u8(hex + 16, res2);
+}


### PR DESCRIPTION
Add aarch64 Neon version of the `hex` encoding. Since Rust currently didn't implement all the Neon intrinsic correctly, the actual SIMD encoding logic is inside the `hex_neon.c`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/redl0tus/vanitygpg/3)
<!-- Reviewable:end -->
