### PR TITLE
hex: add loongarch64 lsx support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,4 +4,15 @@ fn main() {
         use cc::Build;
         Build::new().file("src/hex_neon.c").compile("hex");
     }
+    
+    #[cfg(target_arch = "loongarch64")]
+    {
+        use cc::Build;
+        let result = Build::new().file("src/hex_lsx.c").flag("-mlsx").try_compile("hex");
+
+        match result {
+            Ok(_) => println!("cargo:rustc-cfg=compilerSupportLSX"),
+            Err(_) => {}
+        }
+    }
 }

--- a/src/hex_lsx.c
+++ b/src/hex_lsx.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <lsxintrin.h>
+
+const uint8_t nine = 9;
+const uint8_t and_mask = 0xf;
+const uint8_t bin_a = 0x37;
+
+void sha1_to_hex_lsx(const uint8_t *binary, uint8_t *hex) {
+  __m128i ascii_zero = __lsx_vldrepl_b((const uint8_t*)"0", 0);
+  __m128i nines = __lsx_vldrepl_b(&nine, 0);
+  __m128i ascii_a = __lsx_vldrepl_b(&bin_a, 0);
+  __m128i and4bits = __lsx_vldrepl_b(&and_mask, 0);
+
+  __m128i invec = __lsx_vld((__m128i * const)binary, 0);
+
+  __m128i masked1 = __lsx_vand_v(invec, and4bits);
+  __m128i masked2 = __lsx_vand_v(__lsx_vsrli_b((invec), 4), and4bits);
+
+  __m128i cmpmask1 = __lsx_vslt_bu(nines, masked1);
+  __m128i cmpmask2 = __lsx_vslt_bu(nines, masked2);
+
+  __m128i masked1_k = __lsx_vsadd_bu(masked1, __lsx_vbitsel_v(ascii_zero, ascii_a, cmpmask1));
+  __m128i masked2_k = __lsx_vsadd_bu(masked2, __lsx_vbitsel_v(ascii_zero, ascii_a, cmpmask2));
+
+  __m128i res1 = __lsx_vilvl_b(masked1_k, masked2_k);
+  __m128i res2 = __lsx_vilvh_b(masked1_k, masked2_k);
+  
+  __lsx_vst(res1, hex, 0);
+  __lsx_vst(res2, hex + 16, 0);
+}


### PR DESCRIPTION
Add LoongArch SX support to `hex` encoding, the actual code is in `hex_lsx.c`, in case to use this change, your system has been installed the gcc/clang that enabled the LoongArch SX instruction support.

P.S: LoongArch ASX support is also written, but the performance is basically the same as the LoongArch SX version on Loongson 3C5000L.